### PR TITLE
feat: Introduce new viscoelastic variables and update implementation

### DIFF
--- a/src-local/log-conform-viscoelastic.h
+++ b/src-local/log-conform-viscoelastic.h
@@ -1,0 +1,366 @@
+/** Title: log-conform-viscoelastic.h
+# Version: 10.0
+# Main feature: A exists in across the domain and relaxes according to \lambda. The stress only acts according to G.
+# Author: Vatsal Sanjay
+# vatsalsanjay@gmail.com
+# Physics of Fluids
+# Updated: Jul 23, 2024
+*/
+
+// The code is same as http://basilisk.fr/src/log-conform.h but written for purely elastic limit (lambda \to \infty)
+
+// In this code, conform_p, conform_qq are in fact the Conformation tensor.  
+
+#include "bcg.h"
+
+symmetric tensor conform_p[], tau_p[];
+#if AXI
+scalar conform_qq[], tau_qq[];
+#endif
+
+event defaults (i = 0) {
+  if (is_constant (a.x))
+    a = new face vector;
+
+  foreach() {
+    foreach_dimension(){
+      tau_p.x.x[] = 0.;
+      conform_p.x.x[] = 1.;
+    }
+    tau_p.x.y[] = 0.;
+    conform_p.x.y[] = 0.;
+#if AXI
+    tau_qq[] = 0;
+    conform_qq[] = 1.;
+#endif
+  }
+
+  for (scalar s in {tau_p}) {
+    s.v.x.i = -1; // just a scalar, not the component of a vector
+    foreach_dimension(){
+      if (s.boundary[left] != periodic_bc) {
+        s[left] = neumann(0);
+	      s[right] = neumann(0);
+      }
+    }
+  }
+
+  for (scalar s in {conform_p}) {
+    s.v.x.i = -1; // just a scalar, not the component of a vector
+    foreach_dimension(){
+      if (s.boundary[left] != periodic_bc) {
+        s[left] = neumann(0);
+	      s[right] = neumann(0);
+      }
+    }
+  }
+
+#if AXI
+  scalar s1 = tau_p.x.y;
+  s1[bottom] = dirichlet (0.);  
+#endif 
+
+#if AXI
+  scalar s2 = conform_p.x.y;
+  s2[bottom] = dirichlet (0.);  
+#endif 
+}
+
+/**
+## Numerical Scheme
+
+The first step is to implement a routine to calculate the eigenvalues
+and eigenvectors of the conformation tensor $\mathbf{A}$.
+
+These structs ressemble Basilisk vectors and tensors but are just
+arrays not related to the grid. */
+
+typedef struct { double x, y;}   pseudo_v;
+typedef struct { pseudo_v x, y;} pseudo_t;
+
+static void diagonalization_2D (pseudo_v * Lambda, pseudo_t * R, pseudo_t * A)
+{
+  /**
+  The eigenvalues are saved in vector $\Lambda$ computed from the
+  trace and the determinant of the symmetric conformation tensor
+  $\mathbf{A}$. */
+
+  if (sq(A->x.y) < 1e-15) {
+    R->x.x = R->y.y = 1.;
+    R->y.x = R->x.y = 0.;
+    Lambda->x = A->x.x; Lambda->y = A->y.y;
+    return;
+  }
+
+  double T = A->x.x + A->y.y; // Trace of the tensor
+  double D = A->x.x*A->y.y - sq(A->x.y); // Determinant
+
+  /**
+  The eigenvectors, $\mathbf{v}_i$ are saved by columns in tensor
+  $\mathbf{R} = (\mathbf{v}_1|\mathbf{v}_2)$. */
+
+  R->x.x = R->x.y = A->x.y;
+  R->y.x = R->y.y = -A->x.x;
+  double s = 1.;
+  for (int i = 0; i < dimension; i++) {
+    double * ev = (double *) Lambda;
+    ev[i] = T/2 + s*sqrt(sq(T)/4. - D);
+    s *= -1;
+    double * Rx = (double *) &R->x;
+    double * Ry = (double *) &R->y;
+    Ry[i] += ev[i];
+    double mod = sqrt(sq(Rx[i]) + sq(Ry[i]));
+    Rx[i] /= mod;
+    Ry[i] /= mod;
+  }
+}
+
+/**
+The stress tensor depends on previous instants and has to be
+integrated in time. In the log-conformation scheme the advection of
+the stress tensor is circumvented, instead the conformation tensor,
+$\mathbf{A}$ (or more precisely the related variable $\Psi$) is
+advanced in time.
+
+In what follows we will adopt a scheme similar to that of [Hao \& Pan
+(2007)](#hao2007). We use a split scheme, solving successively
+
+a) the upper convective term:
+$$
+\partial_t \Psi = 2 \mathbf{B} + (\Omega \cdot \Psi -\Psi \cdot \Omega)
+$$
+b) the advection term:
+$$
+\partial_t \Psi + \nabla \cdot (\Psi \mathbf{u}) = 0
+$$
+c) the model term (but set in terms of the conformation 
+tensor $\mathbf{A}$). In an Oldroyd-B viscoelastic fluid, the model is
+$$ 
+\partial_t \mathbf{A} = -\frac{\mathbf{f}_r (\mathbf{A})}{\lambda}
+$$
+
+The implementation below assumes that the values of $\Psi$ and
+$\conform_p$ are never needed simultaneously. This means that $\conform_p$ can
+be used to store (temporarily) the values of $\Psi$ (i.e. $\Psi$ is
+just an alias for $\conform_p$). */
+
+event tracer_advection(i++)
+{
+    tensor Psi = conform_p;
+#if AXI
+    scalar Psiqq = conform_qq;
+#endif
+
+    /**
+    ### Computation of $\Psi = \log \mathbf{A}$ and upper convective term */
+
+    foreach() {
+      /**
+        We assume that the stress tensor $\mathbf{\tau}_p$ depends on the
+        conformation tensor $\mathbf{A}$ as follows
+        $$
+        \mathbf{\tau}_p = G_p (\mathbf{A}) =
+        G_p (\mathbf{A} - I)
+        $$
+      */
+
+      pseudo_t A;
+      A.x.y = conform_p.x.y[];
+
+      foreach_dimension()
+        A.x.x = conform_p.x.x[];
+      /**
+       In the axisymmetric case, $\Psi_{\theta \theta} = \log A_{\theta
+       \theta}$. Therefore $\Psi_{\theta \theta} = \log [ ( 1 + \text{fa}
+       \tau_{p_{\theta \theta}})]$. */
+
+#if AXI
+      double Aqq = conform_qq[]; 
+      Psiqq[] = log (Aqq); 
+#endif
+
+      /**
+      The conformation tensor is diagonalized through the
+      eigenvector tensor $\mathbf{R}$ and the eigenvalues diagonal
+      tensor, $\Lambda$. */
+
+      pseudo_v Lambda;
+      pseudo_t R;
+      diagonalization_2D (&Lambda, &R, &A);
+      
+      /**
+      $\Psi = \log \mathbf{A}$ is easily obtained after diagonalization, 
+      $\Psi = R \cdot \log(\Lambda) \cdot R^T$. */
+      
+      Psi.x.y[] = R.x.x*R.y.x*log(Lambda.x) + R.y.y*R.x.y*log(Lambda.y);
+      foreach_dimension()
+      	Psi.x.x[] = sq(R.x.x)*log(Lambda.x) + sq(R.x.y)*log(Lambda.y);
+
+        /**
+        We now compute the upper convective term $2 \mathbf{B} +
+        (\Omega \cdot \Psi -\Psi \cdot \Omega)$.
+
+        The diagonalization will be applied to the velocity gradient
+        $(\nabla u)^T$ to obtain the antisymmetric tensor $\Omega$ and
+        the traceless, symmetric tensor, $\mathbf{B}$. If the conformation
+        tensor is $\mathbf{I}$, $\Omega = 0$ and $\mathbf{B}= \mathbf{D}$.  */
+
+      pseudo_t B;
+      double OM = 0.;
+      if (fabs(Lambda.x - Lambda.y) <= 1e-20) {
+	B.x.y = (u.y[1,0] - u.y[-1,0] +
+		 u.x[0,1] - u.x[0,-1])/(4.*Delta); 
+	foreach_dimension() 
+	  B.x.x = (u.x[1,0] - u.x[-1,0])/(2.*Delta);
+      }
+      else {
+	pseudo_t M;
+	foreach_dimension() {
+	  M.x.x = (sq(R.x.x)*(u.x[1] - u.x[-1]) +
+		   sq(R.y.x)*(u.y[0,1] - u.y[0,-1]) +
+		   R.x.x*R.y.x*(u.x[0,1] - u.x[0,-1] + 
+				u.y[1] - u.y[-1]))/(2.*Delta);
+	  M.x.y = (R.x.x*R.x.y*(u.x[1] - u.x[-1]) + 
+		   R.x.y*R.y.x*(u.y[1] - u.y[-1]) +
+		   R.x.x*R.y.y*(u.x[0,1] - u.x[0,-1]) +
+		   R.y.x*R.y.y*(u.y[0,1] - u.y[0,-1]))/(2.*Delta);
+	}
+	double omega = (Lambda.y*M.x.y + Lambda.x*M.y.x)/(Lambda.y - Lambda.x);
+	OM = (R.x.x*R.y.y - R.x.y*R.y.x)*omega;
+	
+	B.x.y = M.x.x*R.x.x*R.y.x + M.y.y*R.y.y*R.x.y;
+	foreach_dimension()
+	  B.x.x = M.x.x*sq(R.x.x)+M.y.y*sq(R.x.y);	
+      }
+
+        /**
+        We now advance $\Psi$ in time, adding the upper convective
+        contribution. */
+
+      double s = - Psi.x.y[];
+      Psi.x.y[] += dt*(2.*B.x.y + OM*(Psi.y.y[] - Psi.x.x[]));
+      foreach_dimension() {
+	s *= -1;
+	Psi.x.x[] += dt*2.*(B.x.x + s*OM);
+      }
+
+      /**
+      In the axisymmetric case, the governing equation for $\Psi_{\theta
+      \theta}$ only involves that component, 
+      $$ 
+      \Psi_{\theta \theta}|_t - 2 L_{\theta \theta} = 
+      \frac{\mathbf{f}_r(e^{-\Psi_{\theta \theta}})}{\lambda} 
+      $$
+      with $L_{\theta \theta} = u_y/y$. Therefore step (a) for
+      $\Psi_{\theta \theta}$ is */
+
+#if AXI
+      Psiqq[] += dt*2.*u.y[]/max(y, 1e-20);
+#endif
+
+}
+
+  /**
+  ### Advection of $\Psi$
+  
+  We proceed with step (b), the advection of the log of the
+  conformation tensor $\Psi$. */
+
+#if AXI
+  advection ({Psi.x.x, Psi.x.y, Psi.y.y, Psiqq}, uf, dt);
+#else
+  advection ({Psi.x.x, Psi.x.y, Psi.y.y}, uf, dt);
+#endif
+
+    /**
+    ### Convert back to \conform_p */
+
+    foreach() {
+      /**
+      It is time to undo the log-conformation, again by
+      diagonalization, to recover the conformation tensor $\mathbf{A}$
+      and to perform step (c).*/
+
+      pseudo_t A = {{Psi.x.x[], Psi.x.y[]}, {Psi.y.x[], Psi.y.y[]}}, R;
+      pseudo_v Lambda;
+      diagonalization_2D (&Lambda, &R, &A);
+      Lambda.x = exp(Lambda.x), Lambda.y = exp(Lambda.y);
+      
+      A.x.y = R.x.x*R.y.x*Lambda.x + R.y.y*R.x.y*Lambda.y;
+      foreach_dimension()
+        A.x.x = sq(R.x.x)*Lambda.x + sq(R.x.y)*Lambda.y;
+#if AXI
+      double Aqq = exp(Psiqq[]);
+#endif
+
+      /**
+      We perform now step (c) by integrating 
+      $\mathbf{A}_t = -\mathbf{f}_r (\mathbf{A})/\lambda$ to obtain
+      $\mathbf{A}^{n+1}$. This step is analytic,
+      $$
+      \int_{t^n}^{t^{n+1}}\frac{d \mathbf{A}}{\mathbf{I}- \mathbf{A}} = 
+      \frac{\Delta t}{\lambda}
+      $$
+      */
+
+     double intFactor = lambda[] != 0. ? exp(-dt/lambda[]): 0.;
+     
+#if AXI
+      Aqq = (1. - intFactor) + intFactor*exp(Psiqq[]);
+#endif
+
+      A.x.y *= intFactor;
+      foreach_dimension()
+        A.x.x = (1. - intFactor) + A.x.x*intFactor;
+
+      /**
+        Then the Conformation tensor $\mathcal{A}_p^{n+1}$ is restored from
+        $\mathbf{A}^{n+1}$.  */
+      
+      conform_p.x.y[] = A.x.y;
+      tau_p.x.y[] = Gp[]*A.x.y;
+#if AXI
+      conform_qq[] = Aqq;
+      tau_qq[] = Gp[]*(Aqq - 1.);
+#endif
+
+      foreach_dimension(){
+        conform_p.x.x[] = A.x.x;
+        tau_p.x.x[] = Gp[]*(A.x.x - 1.);
+      }
+
+  }
+}
+
+/**
+### Divergence of the viscoelastic stress tensor
+
+The viscoelastic stress tensor $\mathbf{\tau}_p$ is defined at cell centers
+while the corresponding force (acceleration) will be defined at cell
+faces. Two terms contribute to each component of the momentum
+equation. For example the $x$-component in Cartesian coordinates has
+the following terms: $\partial_x \mathbf{\tau}_{p_{xx}} + \partial_y
+\mathbf{\tau}_{p_{xy}}$. The first term is easy to compute since it can be
+calculated directly from center values of cells sharing the face. The
+other one is harder. It will be computed from vertex values. The
+vertex values are obtained by averaging centered values.  Note that as
+a result of the vertex averaging cells `[]` and `[-1,0]` are not
+involved in the computation of shear. */
+
+event acceleration (i++)
+{
+  face vector av = a;
+  foreach_face()
+    if (fm.x[] > 1e-20) {
+      double shear = (tau_p.x.y[0,1]*cm[0,1] + tau_p.x.y[-1,1]*cm[-1,1] -
+		      tau_p.x.y[0,-1]*cm[0,-1] - tau_p.x.y[-1,-1]*cm[-1,-1])/4.;
+      av.x[] += (shear + cm[]*tau_p.x.x[] - cm[-1]*tau_p.x.x[-1])*
+	alpha.x[]/(sq(fm.x[])*Delta);
+    }
+#if AXI
+  foreach_face(y)
+    if (y > 0.)
+      av.y[] -= (tau_qq[] + tau_qq[0,-1])*alpha.y[]/sq(y)/2.;
+#endif
+}
+

--- a/src-local/three-phase-nonCoalescing-viscoelastic.h
+++ b/src-local/three-phase-nonCoalescing-viscoelastic.h
@@ -1,0 +1,157 @@
+/**
+# Three-phase interfacial flows: two phases (f1, f2) are non-coalescing and the third (f1 = f2 = 0) is always air
+
+# Version 0.2
+# Author: Vatsal Sanjay
+# vatsalsanjay@gmail.com
+# Physics of Fluids
+# Last Updated: Jul 23, 2024
+
+The interface between the fluids is tracked with a Volume-Of-Fluid
+method. The volume fraction in drop is $f1=1$ and $f2=0$. In the thin film, it is $f2=1$ and $f1=0$. Air (fluid 3) is $f1 = f2 = 0$. The densities and dynamic viscosities for fluid 1 and 2 are *rho1*, *mu1*, *rho3*, *mu2*, respectively.
+**Note:** The drop and the film are defined by different VoF fields, but have same properties (density and viscosity).
+*/
+
+#include "vof.h"
+/**
+Instead of one VoF tracer, we define two, f1 and f2.
+*/
+scalar f1[], f2[], *interfaces = {f1, f2};
+(const) scalar Gp = unity; // elastic modulus
+(const) scalar lambda = unity; // relaxation time
+
+double rho1 = 1., mu1 = 0., rho2 = 1., mu2 = 0., rho3 = 1., mu3 = 0.;
+double G1 = 0., G2 = 0., G3 = 0.; // elastic moduli
+double lambda1 = 0., lambda2 = 0., lambda3 = 0.; // relaxation times
+double TOLelastic = 1e-1; // tolerance for elastic modulus # TODO: FIX_ME, ideally we should not have to use such a large tolerance :(
+/**
+Auxilliary fields are necessary to define the (variable) specific
+volume $\alpha=1/\rho$ as well as the cell-centered density. */
+
+face vector alphav[];
+scalar rhov[];
+scalar Gpd[];
+scalar lambdapd[];
+
+event defaults (i = 0) {
+  alpha = alphav;
+  rho = rhov;
+  Gp = Gpd;
+  lambda = lambdapd;
+  /**
+  If the viscosity is non-zero, we need to allocate the face-centered
+  viscosity field. */
+  mu = new face vector;
+}
+
+/**
+The density and viscosity are defined using arithmetic averages by
+default. The user can overload these definitions to use other types of
+averages (i.e. harmonic). The difference comes in how we call these averages.
+$$
+\hat{A} = (f_1+f_2) + (1-f_1-f_2)\frac{A_g}{A_l}\,\,\,\forall\,\,\,A \in \{\mu,\rho\}
+$$
+*/
+
+#ifndef rho
+#define rho(f1, f2)  (clamp(f1,0.,1.)*rho1 + clamp(f2,0.,1.)*rho2 + clamp(1.-f1-f2,0.,1.)*rho3)
+#endif
+#ifndef mu
+#define mu(f1, f2)  (clamp(f1,0.,1.)*mu1 + clamp(f2,0.,1.)*mu2 + clamp(1.-f1-f2,0.,1.)*mu3)
+#endif
+
+/**
+We have the option of using some "smearing" of the density/viscosity
+jump. It is modified to take into account that there are two VoF tracers. */
+
+#ifdef FILTERED
+scalar sf1[], sf2[], *smearInterfaces = {sf1, sf2};
+#else
+#define sf1 f1
+#define sf2 f2
+scalar *smearInterfaces = {sf1, sf2};
+#endif
+
+event tracer_advection (i++) {
+
+  /**
+  When using smearing of the density jump, we initialise *sf* with the
+  vertex-average of *f*. Introduce for loops to ensure that smearing is done properly. */
+  #ifdef FILTERED
+    int counter1 = 0;
+    for (scalar sf in smearInterfaces){
+      counter1++;
+      int counter2 = 0;
+      for (scalar f in interfaces){
+        counter2++;
+        if (counter1 == counter2){
+          // fprintf(ferr, "%s %s\n", sf.name, f.name);
+        #if dimension <= 2
+            foreach(){
+              sf[] = (4.*f[] +
+          	    2.*(f[0,1] + f[0,-1] + f[1,0] + f[-1,0]) +
+          	    f[-1,-1] + f[1,-1] + f[1,1] + f[-1,1])/16.;
+            }
+        #else // dimension == 3
+            foreach(){
+              sf[] = (8.*f[] +
+          	    4.*(f[-1] + f[1] + f[0,1] + f[0,-1] + f[0,0,1] + f[0,0,-1]) +
+          	    2.*(f[-1,1] + f[-1,0,1] + f[-1,0,-1] + f[-1,-1] +
+          		f[0,1,1] + f[0,1,-1] + f[0,-1,1] + f[0,-1,-1] +
+          		f[1,1] + f[1,0,1] + f[1,-1] + f[1,0,-1]) +
+          	    f[1,-1,1] + f[-1,1,1] + f[-1,1,-1] + f[1,1,1] +
+          	    f[1,1,-1] + f[-1,-1,-1] + f[1,-1,-1] + f[-1,-1,1])/64.;
+            }
+        #endif
+        }
+      }
+    }
+    #endif
+
+  #if TREE
+    for (scalar sf in smearInterfaces){
+      sf.prolongation = refine_bilinear;
+      sf.dirty = true; // boundary conditions need to be updated
+    }
+  #endif
+}
+
+
+event properties (i++) {
+
+  foreach_face() {
+    double ff1 = (sf1[] + sf1[-1])/2.;
+    double ff2 = (sf2[] + sf2[-1])/2.;
+    alphav.x[] = fm.x[]/rho(ff1, ff2);
+    face vector muv = mu;
+    muv.x[] = fm.x[]*mu(ff1, ff2);
+  }
+
+  foreach(){
+    rhov[] = cm[]*rho(sf1[], sf2[]);
+
+    Gpd[] = 0.;
+    lambdapd[] = 0.;
+
+  if (clamp(sf1[], 0., 1.) > TOLelastic){
+    Gpd[] += G1*clamp(sf1[], 0., 1.);
+    lambdapd[] += lambda1*clamp(sf1[], 0., 1.);
+  }
+  if (clamp(sf2[], 0., 1.) > TOLelastic){
+    Gpd[] += G2*clamp(sf2[], 0., 1.);
+    lambdapd[] += lambda2*clamp(sf2[], 0., 1.);
+  }
+  if (clamp((1-sf1[]-sf2[]), 0., 1.) > TOLelastic){
+    Gpd[] += G3*clamp((1-sf1[]-sf2[]), 0., 1.);
+    lambdapd[] += lambda3*clamp((1-sf1[]-sf2[]), 0., 1.);
+  }
+  
+  }
+
+#if TREE
+  for (scalar sf in smearInterfaces){
+    sf.prolongation = fraction_refine;
+    sf.dirty = true; // boundary conditions need to be updated
+  }
+#endif
+}


### PR DESCRIPTION
The changes introduce new viscoelastic variables and update the implementation for the log-conform-viscoelastic.h file. The key changes are:

- Added new variables `Ec_d`, `De_d`, `Ec_h`, `De_h`, `Ec_c`, and `De_c` to model the viscoelastic behavior of the drop, hypha, and cytoplasm.
- Updated the implementation of the log-conform-viscoelastic.h file to include a new numerical scheme for computing the eigenvalues and eigenvectors of the conformation tensor.
- Implemented a split scheme to advance the conformation tensor in time, including the upper convective term, advection term, and model term.
- Utilized the `conform_p` and `conform_qq` variables to store the values of the conformation tensor, optimizing the memory usage.

These changes aim to improve the modeling of the viscoelastic behavior in the simulation, providing a more accurate representation of the underlying physical phenomena.