### PR TITLE
feat: Implement non-coalescence data extraction code

### DIFF
--- a/getData-elastic-nonCoalescence.c
+++ b/getData-elastic-nonCoalescence.c
@@ -45,7 +45,7 @@ int main(int a, char const *arguments[])
     double D33 = (u.x[1,0] - u.x[-1,0])/(2*Delta);
     double D13 = 0.5*( (u.y[1,0] - u.y[-1,0] + u.x[0,1] - u.x[0,-1])/(2*Delta) );
     double D2 = (sq(D11)+sq(D22)+sq(D33)+2.0*sq(D13));
-    D2c[] = 2*( Oh1*clamp(f1[]*(1-f2[]), 0., 1.) + Oh2*clamp(f1[]*f2[], 0., 1.) + Oh3*clamp(1-f1[], 0., 1.) )*D2;
+    D2c[] = 2*( Oh1*clamp(f1[], 0., 1.) + Oh2*clamp(f2[], 0., 1.) + Oh3*clamp(1-f1[]-f2[], 0., 1.) )*D2;
     
     if (D2c[] > 0.){
       D2c[] = log(D2c[])/log(10);


### PR DESCRIPTION
The changes implemented in this commit add the ability to extract data from a simulation snapshot that accounts for non-coalescence of two fluid phases. The key changes include:

- Modifying the calculation of the strain rate tensor (D2c) to consider the presence of a third fluid phase, in addition to the two existing phases.
- Updating the calculation of the strain rate tensor (D2c) to use the appropriate Ohnesorge numbers for each fluid phase.
- Preserving the existing functionality for calculating the velocity (vel) and trace of the polymer stress tensor (trA).

These changes enable the extraction of data from simulation snapshots that involve non-coalescence of multiple fluid phases, which is an important capability for analyzing complex fluid dynamics phenomena.